### PR TITLE
Use utils.directory_exists to detect collectd.conf path

### DIFF
--- a/collectd/monitor/config-replacer.lua
+++ b/collectd/monitor/config-replacer.lua
@@ -364,7 +364,7 @@ ConfigReplacer.new = function(task_id, options)
       if self.options.ConfigPath then
          return self.options.ConfigPath
       elseif utils.file_exists("/usr/sbin/collectd") then
-         if utils.file_exists("/etc/collectd/collectd.conf") then
+         if utils.directory_exists("/etc/collectd") then
             return "/etc/collectd/collectd.conf"
          else
             return "/etc/collectd.conf"

--- a/collectd/monitor/utils.lua
+++ b/collectd/monitor/utils.lua
@@ -48,6 +48,16 @@ utils.file_exists = function(path)
    end
 end
 
+utils.directory_exists = function(path)
+   local unix = require('unix')
+   local dir, err = unix.stat(path)
+   if err then
+      return false
+   else
+      return unix.S_ISDIR(dir.mode)
+   end
+end
+
 utils.run_command = function(command_line)
    local cmdline = command_line .. "; echo $?"
    local pipe = io.popen(cmdline)


### PR DESCRIPTION
There is a case that config_path() is called when
it was already renamed for creating backup file. (collectd.conf.orig)

Thus, it must return a consistent path that does not depend
on the existence of collectd.conf