### PR TITLE
Revert "Use utils.directory_exists to detect collectd.conf path"

### DIFF
--- a/collectd/monitor/config-replacer.lua
+++ b/collectd/monitor/config-replacer.lua
@@ -364,7 +364,7 @@ ConfigReplacer.new = function(task_id, options)
       if self.options.ConfigPath then
          return self.options.ConfigPath
       elseif utils.file_exists("/usr/sbin/collectd") then
-         if utils.directory_exists("/etc/collectd") then
+         if utils.file_exists("/etc/collectd/collectd.conf") then
             return "/etc/collectd/collectd.conf"
          else
             return "/etc/collectd.conf"

--- a/collectd/monitor/utils.lua
+++ b/collectd/monitor/utils.lua
@@ -48,16 +48,6 @@ utils.file_exists = function(path)
    end
 end
 
-utils.directory_exists = function(path)
-   local unix = require('unix')
-   local dir, err = unix.stat(path)
-   if err then
-      return false
-   else
-      return unix.S_ISDIR(dir.mode)
-   end
-end
-
 utils.run_command = function(command_line)
    local cmdline = command_line .. "; echo $?"
    local pipe = io.popen(cmdline)


### PR DESCRIPTION
Reverts clear-code/lua-collectd-monitor#4

Because it conflicts with README.md (it let a user create /etc/collectd directory) on CentOS. It should be merged with modifying README.md, or we should introduce more proper detecting mechanism for the path.